### PR TITLE
App Install Location

### DIFF
--- a/Napply/AndroidManifest.xml
+++ b/Napply/AndroidManifest.xml
@@ -20,6 +20,7 @@ along with Napply. If not, see <http://www.gnu.org/licenses/>.
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 	package="fr.miximum.napply"
+	android:installLocation="auto"
 	android:versionCode="2"
 	android:versionName="1.2">
 


### PR DESCRIPTION
The internal memory of my device is quite small, this PR should allow users to easily move the app to the microSD.

"To allow the system to install your application on the external storage, modify your manifest file to include the android:installLocation attribute in the element, with a value of either "preferExternal" or "auto"." (source: https://developer.android.com/guide/topics/data/install-location.html)

Thank you very much for your awesome app :)
